### PR TITLE
Add babel register for node compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "8.0"
-  - "7.0"
+  - "8"
+  - "6"
 script:
   - npm link
   - npm t

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+require('babel-register')({
+  presets: ['env'],
+  plugins: ['transform-object-rest-spread']
+});
+
 var yargs = require('yargs');
 
 yargs


### PR DESCRIPTION
fix #53 

Note:
- This can be removed once Node 10 becomes the new LTS
- Node 8 is the **recommended** version right now
- Node 6 will be ended by [April 2019](https://github.com/nodejs/Release#release-schedule), so I won't give much support for this version or 7, obviously.