### PR TITLE
implement multiview for start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "has-yarn": "^1.0.0",
     "inquirer": "^6.0.0",
     "isomorphic-style-loader": "^4.0.0",
+    "multiview": "^2.5.3",
     "null-loader": "^0.1.1",
     "start-server-webpack-plugin": "3.0.0-rc3",
     "url-loader": "^1.0.1",

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -13,7 +13,7 @@ function cleanBuild() {
 
 module.exports = argv => {
   if (argv.both) {
-    log('Running both client...');
+    log('Running both CRA client and server...');
     const mv = require('multiview')({
       efficient: true
     });

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -11,33 +11,44 @@ function cleanBuild() {
   });
 }
 
-cleanBuild().then(() => {
-  const config = require('../config/webpack.config');
-  const ins = webpack(config);
-  ins.watch(config.watchOptions, (err, stats) => {
-    console.clear();
-    if (err) {
-      console.error(err.stack || err);
-      if (err.details) {
-        console.error(err.details);
+module.exports = argv => {
+  if (argv.both) {
+    log('Running both client...');
+    const mv = require('multiview')({
+      efficient: true
+    });
+    mv.spawn('npx', ['cra-universal', 'start']);
+    mv.spawn('npm', ['start']);
+    return;
+  }
+  cleanBuild().then(() => {
+    const config = require('../config/webpack.config');
+    const ins = webpack(config);
+    ins.watch(config.watchOptions, (err, stats) => {
+      console.clear();
+      if (err) {
+        console.error(err.stack || err);
+        if (err.details) {
+          console.error(err.details);
+        }
+        return;
       }
-      return;
-    }
 
-    const info = stats.toJson();
+      const info = stats.toJson();
 
-    if (stats.hasErrors()) {
-      console.error(info.errors);
-    }
+      if (stats.hasErrors()) {
+        console.error(info.errors);
+      }
 
-    if (stats.hasWarnings()) {
-      console.warn(info.warnings);
-    }
-    console.log(
-      stats.toString({
-        modules: false,
-        colors: true // Shows colors in the console
-      })
-    );
+      if (stats.hasWarnings()) {
+        console.warn(info.warnings);
+      }
+      console.log(
+        stats.toString({
+          modules: false,
+          colors: true // Shows colors in the console
+        })
+      );
+    });
   });
-});
+};

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,16 @@ yargs
   .command(
     'start',
     'Start CRA server',
-    () => {},
+    c => {
+      return c.options({
+        both: {
+          alias: 'b',
+          description: 'Start both CRA client and server (beta)'
+        }
+      });
+    },
     argv => {
-      require('./cli/start');
+      require('./cli/start')(argv);
     }
   )
   .command(

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,6 +251,10 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
+ansi-regex@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-1.1.1.tgz#41c847194646375e6a1a5d10c3ca054ef9fc980d"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -258,6 +262,10 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-state@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/ansi-state/-/ansi-state-1.0.5.tgz#0aeda248409664ac16b589121ac831cd6f721aa7"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1310,6 +1318,10 @@ buffer-from@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
+buffer-shims@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -1498,6 +1510,10 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+
 clorox@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clorox/-/clorox-1.0.3.tgz#6fa63653f280c33d69f548fb14d239ddcfa1590d"
@@ -1526,6 +1542,23 @@ color-convert@^1.9.0:
 color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+columnify@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.3.2.tgz#61bd578a9269ae6fd949ce36fff589f3702c7867"
+  dependencies:
+    strip-ansi "^2.0.0"
+    wcwidth "^1.0.0"
+
+columns@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/columns/-/columns-0.8.0.tgz#c272fd81a18704423b2a3842e99d1920a577edd9"
+  dependencies:
+    ansi-state "~1.0.5"
+    heartbeats "~3.1.0"
+    split "~0.3.2"
+    strip-bom "~1.0.0"
+    wcwidth.js "~1.0.0"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -1812,6 +1845,12 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+defaults@^1.0.0, defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -2059,6 +2098,12 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
+event-transmitter@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/event-transmitter/-/event-transmitter-2.0.0.tgz#7d58aeb72abb47c1e7eab0d7bf78033c0de33493"
+  dependencies:
+    readable-stream "2.2.3"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2282,6 +2327,10 @@ find-up@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   dependencies:
     locate-path "^3.0.0"
+
+first-chunk-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -2598,6 +2647,10 @@ hawk@~6.0.2:
     cryptiles "3.x.x"
     hoek "4.x.x"
     sntp "2.x.x"
+
+heartbeats@~3.1.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/heartbeats/-/heartbeats-3.1.5.tgz#99be8b2392b9075cc9aebebb5831616bceac160e"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -3452,6 +3505,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+keypress@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3718,7 +3775,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3781,6 +3838,17 @@ move-concurrently@^1.0.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+multiview@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/multiview/-/multiview-2.5.3.tgz#4a8ffadea7e2532c7ed3d241113b3db32e486741"
+  dependencies:
+    columns "0.8.0"
+    event-transmitter "2.0.0"
+    keypress "0.2.1"
+    protogram "1.1.3"
+    protogram-help "1.0.2"
+    unparse-args "1.0.1"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -4250,6 +4318,10 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkginfo@~0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -4312,6 +4384,10 @@ private@^0.1.6, private@^0.1.7, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -4337,6 +4413,20 @@ prop-types@^15.5.10:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+protogram-help@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/protogram-help/-/protogram-help-1.0.2.tgz#fb49cacff85fe80edb3568ac6eac78af0b032a19"
+  dependencies:
+    columnify "~1.3.2"
+    pkginfo "~0.3.0"
+
+protogram@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/protogram/-/protogram-1.1.3.tgz#95f1df709c43310d62c13942baa09b753a688cf1"
+  dependencies:
+    subarg "~1.0.0"
+    unparse-args "~1.0.1"
 
 proxy-addr@~2.0.2:
   version "2.0.3"
@@ -4479,6 +4569,18 @@ read-pkg@^1.0.0:
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
+  dependencies:
+    buffer-shims "^1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -4838,6 +4940,10 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shell-escape@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.1.0.tgz#20e996fdd5f0c51be3f3c550119b77723d98e335"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -4966,6 +5072,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@~0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5073,9 +5185,19 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+
+strip-ansi@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-2.0.1.tgz#df62c1aa94ed2f114e1d0f21fd1d50482b79a60e"
+  dependencies:
+    ansi-regex "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -5099,6 +5221,13 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-1.0.0.tgz#85b8862f3844b5a6d5ec8467a93598173a36f794"
+  dependencies:
+    first-chunk-stream "^1.0.0"
+    is-utf8 "^0.2.0"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -5106,6 +5235,12 @@ strip-eof@^1.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+subarg@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  dependencies:
+    minimist "^1.1.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -5185,7 +5320,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6:
+through@2, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5348,6 +5483,12 @@ universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
+unparse-args@1.0.1, unparse-args@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unparse-args/-/unparse-args-1.0.1.tgz#85906d556861045806f97533cd325ad100677078"
+  dependencies:
+    shell-escape "~0.1.0"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -5480,6 +5621,18 @@ watchpack@^1.5.0:
     chokidar "^2.0.2"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+
+wcwidth.js@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wcwidth.js/-/wcwidth.js-1.0.0.tgz#62c19310a3e9c1025cd57f53c35b47acf643fdc3"
+  dependencies:
+    defaults "^1.0.0"
+
+wcwidth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
- Now you can start both CRA client and server and view the terminal side-to-side
  - Previously you had to start both client and server manually, and should be on separate terminal/tab
- Requires `npx`
- How to use: `npx cra-universal start --both`  (`-b` is okay too)