### PR TITLE
Use react-scripts build instead of npm run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Please also visit [create-react-app-express](https://github.com/antonybudianto/c
 * The core middleware is fully **unit-tested**
 * Works alongside `react-scripts`, not as replacement
 
+## Prerequisites
+
+- Node >= 8.6 recommended
+- npx is required
+
 ## Installation
 
 ```sh

--- a/packages/cra-universal/src/cli/build.js
+++ b/packages/cra-universal/src/cli/build.js
@@ -12,7 +12,7 @@ const { log } = require('../util/log');
 
 const cwd = process.cwd();
 const isWindows = process.platform === 'win32';
-const npm = isWindows ? 'npm.cmd' : 'npm';
+const npx = isWindows ? 'npx.cmd' : 'npx';
 const paths = ['build', 'dist', 'server-build'];
 
 function cleanBuild(done) {
@@ -24,7 +24,7 @@ function cleanBuild(done) {
 
 function buildClient() {
   log('Building CRA client...');
-  const clientBuildResult = spawnSync(npm, ['run', 'build'], {
+  const clientBuildResult = spawnSync(npx, ['react-scripts', 'build'], {
     stdio: 'inherit'
   });
   if (clientBuildResult.status !== 0) {


### PR DESCRIPTION
- To make the build flow more consistent