### PR TITLE
New universal handling

### DIFF
--- a/packages/@cra-express/core/src/handle-universal-render.js
+++ b/packages/@cra-express/core/src/handle-universal-render.js
@@ -1,8 +1,0 @@
-const React = require('react');
-const { renderToNodeStream } = require('react-dom/server');
-
-function handleUniversalRender(reactElement) {
-  return (req, res) => renderToNodeStream(reactElement);
-}
-
-export default handleUniversalRender;

--- a/packages/@cra-express/core/src/index.js
+++ b/packages/@cra-express/core/src/index.js
@@ -1,7 +1,5 @@
 import createReactAppExpress from './app';
-import handleUniversalRender from './handle-universal-render';
 
 export {
-  createReactAppExpress,
-  handleUniversalRender
+  createReactAppExpress
 };

--- a/packages/@cra-express/universal-loader/.babelrc
+++ b/packages/@cra-express/universal-loader/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "react"]
+}

--- a/packages/@cra-express/universal-loader/.prettierrc
+++ b/packages/@cra-express/universal-loader/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/packages/@cra-express/universal-loader/package.json
+++ b/packages/@cra-express/universal-loader/package.json
@@ -9,6 +9,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
   "scripts": {
     "build": "babel src -d lib --ignore spec.js",
     "watch": "babel src -d lib --watch --ignore spec.js",

--- a/packages/@cra-express/universal-loader/src/renderer/stream-renderer.js
+++ b/packages/@cra-express/universal-loader/src/renderer/stream-renderer.js
@@ -1,4 +1,7 @@
-export default function streamRenderer(req, res, stream, htmlData, options) {
+import { renderToNodeStream } from 'react-dom/server'
+
+export default function streamRenderer(req, res, reactEl, htmlData, options) {
+  const stream = renderToNodeStream(reactEl)
   const segments = htmlData.split(`<div id="root">`);
   res.write(segments[0] + `<div id="root">`);
   stream.pipe(res, { end: false })

--- a/packages/@cra-express/universal-loader/src/renderer/stream-renderer.spec.js
+++ b/packages/@cra-express/universal-loader/src/renderer/stream-renderer.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+const mockStream = {
+  pipe: jest.fn(),
+  on: jest.fn((type, cb) => cb())
+};
+const mockRenderToNodeStream = () => mockStream;
+
+jest.setMock('react-dom/server', {
+  renderToNodeStream: mockRenderToNodeStream
+});
+
+const streamRenderer = require('./stream-renderer').default;
+
+test('should render without options correctly', () => {
+  const htmlData = `
+  <html>
+    <body>
+      <div id="root"></div>
+    </body>
+  </html>
+  `;
+
+  const element = <div>Hello</div>;
+
+  const req = {};
+  const res = {
+    write: jest.fn(),
+    send: jest.fn(),
+    end: jest.fn()
+  };
+
+  streamRenderer(req, res, element, htmlData, {});
+  expect(res.write).toHaveBeenCalledTimes(2);
+});
+
+test('should render with onEndReplace option', () => {
+  const htmlData = `
+  <html>
+    <body>
+      <div id="root"></div>{{ssr}}
+    </body>
+  </html>
+`;
+
+  const element = <div>Hello</div>;
+
+  const req = {};
+  const res = {
+    write: jest.fn(),
+    send: jest.fn(),
+    end: jest.fn()
+  };
+
+  streamRenderer(req, res, element, htmlData, {
+    onEndReplace: data => data.replace('{{ssr}}', '<div>ssr</div>')
+  });
+  expect(res.write).toHaveBeenCalledTimes(2);
+  expect(res.write).toHaveBeenLastCalledWith(`</div><div>ssr</div>
+    </body>
+  </html>
+`);
+});

--- a/packages/@cra-express/universal-loader/src/renderer/string-renderer.js
+++ b/packages/@cra-express/universal-loader/src/renderer/string-renderer.js
@@ -1,4 +1,7 @@
-export default function stringRenderer(req, res, str, htmlData, options) {
+import { renderToString } from 'react-dom/server'
+
+export default function stringRenderer(req, res, reactEl, htmlData, options) {
+  const str = renderToString(reactEl)
   const segments = htmlData.split(`<div id="root">`);
   if (options.onEndReplace) {
     segments[1] = options.onEndReplace(segments[1])

--- a/packages/@cra-express/universal-loader/src/renderer/string-renderer.spec.js
+++ b/packages/@cra-express/universal-loader/src/renderer/string-renderer.spec.js
@@ -1,4 +1,5 @@
-import stringRenderer from './string-renderer'
+import React from 'react';
+import stringRenderer from './string-renderer';
 
 test('should render without options correctly', () => {
   const htmlData = `
@@ -7,24 +8,24 @@ test('should render without options correctly', () => {
       <div id="root"></div>
     </body>
   </html>
-  `
+  `;
 
-  const str = '<div>Hello</div>'
+  const element = <div>Hello</div>;
 
-  const req = {}
+  const req = {};
   const res = {
     send: jest.fn()
-  }
+  };
 
-  stringRenderer(req, res, str, htmlData, {})
+  stringRenderer(req, res, element, htmlData, {});
   expect(res.send).toHaveBeenCalledWith(`
   <html>
     <body>
-      <div id="root"><div>Hello</div></div>
+      <div id=\"root\"><div data-reactroot=\"\">Hello</div></div>
     </body>
   </html>
-  `)
-})
+  `);
+});
 
 test('should render correctly with onFinish', () => {
   const htmlData = `
@@ -34,32 +35,33 @@ test('should render correctly with onFinish', () => {
       <div id="script"></div>
     </body>
   </html>
-  `
+  `;
 
-  const str = '<div>Hello</div>'
+  const el = <div>Hello</div>;
 
-  const req = {}
+  const req = {};
   const res = {
     send: jest.fn()
-  }
+  };
 
-  stringRenderer(req, res, str, htmlData, {
+  stringRenderer(req, res, el, htmlData, {
     onFinish: (req1, res1, data) => {
       const finalHtml = data.replace(
         '<div id="script"></div>',
-        '<script>window.hello=1</script>')
-      res1.send(finalHtml)
+        '<script>window.hello=1</script>'
+      );
+      res1.send(finalHtml);
     }
-  })
+  });
   expect(res.send).toHaveBeenCalledWith(`
   <html>
     <body>
-      <div id="root"><div>Hello</div></div>
+      <div id=\"root\"><div data-reactroot=\"\">Hello</div></div>
       <script>window.hello=1</script>
     </body>
   </html>
-  `)
-})
+  `);
+});
 
 test('should render correctly with onEndReplace', () => {
   const htmlData = `
@@ -69,28 +71,29 @@ test('should render correctly with onEndReplace', () => {
       <div id="script"></div>
     </body>
   </html>
-  `
+  `;
 
-  const str = '<div>Hello</div>'
+  const el = <div>Hello</div>;
 
-  const req = {}
+  const req = {};
   const res = {
     send: jest.fn()
-  }
+  };
 
-  stringRenderer(req, res, str, htmlData, {
-    onEndReplace: (data) => {
+  stringRenderer(req, res, el, htmlData, {
+    onEndReplace: data => {
       return data.replace(
         '<div id="script"></div>',
-        '<script>window.hello=1</script>')
+        '<script>window.hello=1</script>'
+      );
     }
-  })
+  });
   expect(res.send).toHaveBeenCalledWith(`
   <html>
     <body>
-      <div id="root"><div>Hello</div></div>
+      <div id=\"root\"><div data-reactroot=\"\">Hello</div></div>
       <script>window.hello=1</script>
     </body>
   </html>
-  `)
-})
+  `);
+});

--- a/packages/@cra-express/universal-loader/src/universal.js
+++ b/packages/@cra-express/universal-loader/src/universal.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const http = require('http');
-const streamRenderer = require('./renderer/stream-renderer').default;
+const stringRenderer = require('./renderer/string-renderer').default;
 
 const CRA_CLIENT_PORT = process.env.CRA_CLIENT_PORT || 3000;
 
@@ -44,7 +44,7 @@ function createUniversalMiddleware(options) {
 }
 
 function processRequest(req, res, htmlData, options) {
-  const { universalRender, handleRender = streamRenderer } = options
+  const { universalRender, handleRender = stringRenderer } = options
   const data = universalRender(req, res);
 
   if (data === undefined) {

--- a/packages/cra-universal/templates/package.json
+++ b/packages/cra-universal/templates/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^16.4.1",
-    "react-dom": "^16.4.1"
+    "react-dom": "^16.4.1",
+    "@cra-express/core": "^4.0.0-3"
   },
   "scripts": {
     "crau:start": "cra-universal start",

--- a/packages/cra-universal/templates/server/app.js
+++ b/packages/cra-universal/templates/server/app.js
@@ -2,20 +2,17 @@ const path = require('path');
 const React = require('react');
 import { createReactAppExpress } from '@cra-express/core';
 
-const { default: App } = require('../src/App');
+let App = require('../src/App').default;
 const clientBuildPath = path.resolve(__dirname, '../client');
-
-let AppClass = App;
 
 const app = createReactAppExpress({
   clientBuildPath,
-  universalRender: (req, res) => <AppClass />
+  universalRender: (req, res) => <App />
 });
 
 if (module.hot) {
   module.hot.accept('../src/App', () => {
-    const { default: App } = require('../src/App');
-    AppClass = App;
+    App = require('../src/App').default;
     console.log('✅ Server hot reloaded App');
   });
 }

--- a/packages/cra-universal/templates/server/app.js
+++ b/packages/cra-universal/templates/server/app.js
@@ -1,10 +1,6 @@
 const path = require('path');
-
 const React = require('react');
-import {
-  createReactAppExpress,
-  handleUniversalRender
-} from '@cra-express/core';
+import { createReactAppExpress } from '@cra-express/core';
 
 const { default: App } = require('../src/App');
 const clientBuildPath = path.resolve(__dirname, '../client');
@@ -13,7 +9,7 @@ let AppClass = App;
 
 const app = createReactAppExpress({
   clientBuildPath,
-  universalRender: () => handleUniversalRender(<AppClass />)()
+  universalRender: (req, res) => <AppClass />
 });
 
 if (module.hot) {

--- a/packages/docs/server/app.js
+++ b/packages/docs/server/app.js
@@ -5,7 +5,6 @@ import { getInitialData } from '@cra-express/redux-prefetcher';
 import routes from '../src/routes';
 const path = require('path');
 const React = require('react');
-const ReactDOMServer = require('react-dom/server');
 const { Provider } = require('react-redux');
 const { StaticRouter } = require('react-router');
 const { createStore, applyMiddleware } = require('redux');
@@ -48,7 +47,7 @@ function handleUniversalRender(req, res) {
       );
       return getLoadableState(app).then(loadableState => {
         tag = loadableState.getScriptTag();
-        return ReactDOMServer.renderToNodeStream(app);
+        return app;
       });
     })
     .catch(err => {


### PR DESCRIPTION
### Breaking change
-  New API for `universalRender` callback. It will only accept **return value** of:
    - either React element or 
    - Promise (that resolves React element)
    ```js
    // before: you define "String" twice in both callback
    {
      handleRender: stringRenderer,
      universalRender: (req, res) => renderToString(<App />)
    }

    // after: just return React element! (or Promise of React element )
    {
      universalRender: (req, res) => <App />
    }
    
    // Need to do Nodestream render? Just pass streamRenderer to `handleRender`
    import { streamRenderer } from '@cra-express/universal-loader'
    {
      universalRender: (req, res) => <App />
      handleRender: streamRenderer
    }

    // Want to custom handleRender yourself? Possible now!
    function customRenderer(req, res, reactEl, htmlData, options) { ... }
    ```


- Default `handleRender` will be stringRenderer, due many node stream limitation
- `handleUniversalRender` helper on `@cra-express/core` is **removed**, since it won't be compatible with new API
- Unit tests updated