### PR TITLE
revert build command to use run build

### DIFF
--- a/packages/cra-universal/src/cli/build.js
+++ b/packages/cra-universal/src/cli/build.js
@@ -12,7 +12,7 @@ const { log } = require('../util/log');
 
 const cwd = process.cwd();
 const isWindows = process.platform === 'win32';
-const npx = isWindows ? 'npx.cmd' : 'npx';
+const npm = isWindows ? 'npm.cmd' : 'npm';
 const paths = ['build', 'dist', 'server-build'];
 
 function cleanBuild(done) {
@@ -24,7 +24,7 @@ function cleanBuild(done) {
 
 function buildClient() {
   log('Building CRA client...');
-  const clientBuildResult = spawnSync(npx, ['react-scripts', 'build'], {
+  const clientBuildResult = spawnSync(npm, ['run', 'build'], {
     stdio: 'inherit'
   });
   if (clientBuildResult.status !== 0) {


### PR DESCRIPTION
Current solution will break ejected CRA apps, so reverting to `npm run build` for client build command