### PR TITLE
Setup babel-preset-cra-universal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
+
+# JetBrains IDE project files
+.idea/

--- a/packages/babel-preset-cra-universal/LICENSE
+++ b/packages/babel-preset-cra-universal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Antony Budianto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/babel-preset-cra-universal/README.md
+++ b/packages/babel-preset-cra-universal/README.md
@@ -1,0 +1,23 @@
+# babel-preset-cra-universal
+
+This package includes the [Babel](https://babeljs.io) preset used by [cra-universal](https://github.com/antonybudianto/cra-universal)
+
+## Usage in cra-universal Projects
+
+The easiest way to use this configuration is with cra-universal, which includes it by default. **You don’t need to install it separately in cra-universal projects.**
+
+## Usage Outside of cra-universal
+
+If you want to use this Babel preset in a project not built with cra-universal, you can install it with following steps.
+
+First, [install Babel](https://babeljs.io/docs/setup/).
+
+Then create a file named `.babelrc` with following contents in the root folder of your project:
+
+  ```js
+  {
+    "presets": ["cra-universal"]
+  }
+  ```
+
+This preset uses the `useBuiltIns` option with [transform-object-rest-spread](http://babeljs.io/docs/plugins/transform-object-rest-spread/), which assumes that `Object.assign` is available or polyfilled.

--- a/packages/babel-preset-cra-universal/index.js
+++ b/packages/babel-preset-cra-universal/index.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var preset = {
+  presets: [
+    [require.resolve('babel-preset-env'), { modules: false }],
+    require.resolve('babel-preset-react'),
+  ],
+  plugins: [
+    // class { handleThing = () => { } }
+    require.resolve('babel-plugin-transform-class-properties'),
+
+    // The following two plugins use Object.assign directly, instead of Babel's
+    // extends helper. Note that this assumes `Object.assign` is available.
+    // { ...todo, completed: true }
+    [
+      require.resolve('babel-plugin-transform-object-rest-spread'),
+      {
+        useBuiltIns: true,
+      },
+    ],
+    // Adds syntax support for import()
+    require.resolve('babel-plugin-syntax-dynamic-import'),
+    // Add support for async/await
+    require.resolve('babel-plugin-transform-runtime'),
+  ],
+};
+
+var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+if (env !== 'development' && env !== 'test' && env !== 'production') {
+  throw new Error(
+    'Using `babel-preset-cra-universal` requires that you specify `NODE_ENV` or ' +
+    '`BABEL_ENV` environment variables. Valid values are "development", ' +
+    '"test", and "production". Instead, received: ' +
+    JSON.stringify(env) +
+    '.'
+  );
+}
+
+if (env === 'development' || env === 'test') {
+  preset.plugins.push.apply(preset.plugins, [
+    // Adds component stack to warning messages
+    require.resolve('babel-plugin-transform-react-jsx-source'),
+  ]);
+}
+
+if (env === 'test') {
+  preset.plugins.push.apply(preset.plugins, [
+    // Compiles import() to a deferred require()
+    require.resolve('babel-plugin-dynamic-import-node'),
+    // Transform ES modules to commonjs for Jest support
+    [
+      require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
+      { loose: true },
+    ],
+  ]);
+}
+
+if (env === 'production') {
+  preset.plugins.push.apply(preset.plugins, [
+    require.resolve('babel-plugin-transform-react-remove-prop-types'),
+  ]);
+}
+
+module.exports = preset;

--- a/packages/babel-preset-cra-universal/package.json
+++ b/packages/babel-preset-cra-universal/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "babel-preset-cra-universal",
+  "version": "1.0.0",
+  "description": "Babel preset for cra-universal",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antonybudianto/cra-universal.git"
+  },
+  "author": "Antony Budianto, Kirin Patel",
+  "license": "MIT",
+  "files": [
+    "index.js"
+  ],
+  "dependencies": {
+    "babel-plugin-dynamic-import-node": "1.0.1",
+    "babel-plugin-syntax-dynamic-import": "6.18.0",
+    "babel-plugin-transform-class-properties": "6.23.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.24.0",
+    "babel-plugin-transform-object-rest-spread": "6.23.0",
+    "babel-plugin-transform-react-jsx-source": "6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.3.2",
+    "babel-plugin-transform-runtime": "6.23.0",
+    "babel-preset-env": "1.3.3",
+    "babel-preset-react": "6.23.0"
+  }
+}


### PR DESCRIPTION
Followed suggestion from #128 to implement a custom Babel preset. This is a copy of [babel-preset-razzle](https://github.com/jaredpalmer/razzle/tree/master/packages/babel-preset-razzle) and only offers name changes to the babel-preset-razzle. Should there be any changes needed feel free to request them for this PR and I will try to get to them asap 🙂