### PR TITLE
Use max-age=31536000 and immutable in Cache-Control (#177)

### DIFF
--- a/packages/@cra-express/static-loader/src/index.js
+++ b/packages/@cra-express/static-loader/src/index.js
@@ -25,7 +25,7 @@ function staticLoader(app, options) {
     );
     console.log("Connected to CRA Client dev server");
   } else {
-    app.use(express.static(clientBuildPath, { index: false }));
+    app.use(express.static(clientBuildPath, { index: false, immutable: true, maxAge: 31536000 * 1000 }));
   }
 
   return app;


### PR DESCRIPTION
It sets max-age and immutable options in `express.static`: http://expressjs.com/en/5x/api.html#express.static

The max-age value is recommended by [CRA docs](https://create-react-app.dev/docs/production-build#static-file-caching).

Closes #177 