### PR TITLE
String rendered: return 500 when the renderer has failed

### DIFF
--- a/packages/@cra-express/universal-loader/src/renderer/string-renderer.js
+++ b/packages/@cra-express/universal-loader/src/renderer/string-renderer.js
@@ -1,7 +1,18 @@
-import { renderToString } from 'react-dom/server'
+import { renderToString } from 'react-dom/server';
 
 export default function stringRenderer(req, res, reactEl, htmlData, options) {
-  const str = renderToString(reactEl)
+  let str
+  try {
+    str = renderToString(reactEl)
+  } catch (err) {
+    if (options.renderClientOnError) {
+      str = ''
+    } else {
+      console.error('Error ocurred during the rendered execution', err);
+      res.send(500);
+      return
+    }
+  }
   const segments = htmlData.split(`<div id="root">`);
   if (options.onEndReplace) {
     segments[1] = options.onEndReplace(segments[1])

--- a/packages/@cra-express/universal-loader/src/renderer/string-renderer.spec.js
+++ b/packages/@cra-express/universal-loader/src/renderer/string-renderer.spec.js
@@ -97,3 +97,48 @@ test('should render correctly with onEndReplace', () => {
   </html>
   `);
 });
+
+test('should return 500 when the render is failed', () => {
+  const htmlData = `
+  <html>
+    <body>
+      <div id="root"></div>
+      <div id="script"></div>
+    </body>
+  </html>
+  `;
+
+  const el = <div>{(new Error('Error thrown'))}</div>;
+
+  const req = {};
+  const res = {
+    send: jest.fn()
+  };
+
+  stringRenderer(req, res, el, htmlData, {});
+
+  expect(res.send).toHaveBeenCalledWith(500);
+});
+
+
+test('should render the client app when the render is failed and the renderClientOnError flag is set', () => {
+  const htmlData = `
+  <html>
+    <body>
+      <div id="root"></div>
+      <div id="script"></div>
+    </body>
+  </html>
+  `;
+
+  const el = <div>{(new Error('Error thrown'))}</div>;
+
+  const req = {};
+  const res = {
+    send: jest.fn()
+  };
+
+  stringRenderer(req, res, el, htmlData, { renderClientOnError: true });
+
+  expect(res.send).toHaveBeenCalledWith(htmlData);
+});


### PR DESCRIPTION
In the case when the react components throws an uncaught error the app would not finish the request, which would lead to the request timeout instead of getting the error.

This PR adds a try-catch for the string rendered, that based on parameter `renderClientOnError` would do one of two things:
- `renderClientOnError: false`(default case) it would simply return the 500 error.
- `renderClientOnError: true` it would complete SSR flow but without the rendered components HTML. This case allows avoiding unprocessed `500` errors and rendering client-side app, so the error can be displayed via client

**NOTE:** This PR doesn't include the change to the `stream-renderer`.