### PR TITLE
Clean up demo app, use tags instead of handlebars.

### DIFF
--- a/packages/demo/public/index.html
+++ b/packages/demo/public/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
-  {{HELMET_META}}
+  <script class="helmet-meta"></script>
   <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  {{HELMET_TITLE}}
+  <script class="helmet-title"></script>
 </head>
 
 <body>
@@ -29,7 +29,7 @@
     You need to enable JavaScript to run this app.
   </noscript>
   <div id="root"></div>
-  {{SCRIPT}}
+  <script class="initial-data"></script>
   <!-- Place this tag in your head or just before your close body tag. -->
   <script async defer src="https://buttons.github.io/buttons.js"></script>
   <!--

--- a/packages/demo/server/app.js
+++ b/packages/demo/server/app.js
@@ -13,7 +13,7 @@ const { createStore, applyMiddleware } = require('redux');
 const { default: App } = require('../src/App');
 const { default: reducer } = require('../src/reducers');
 const clientBuildPath = path.resolve(__dirname, '../client');
-let tag = '';
+
 let store;
 let AppClass = App;
 let serverData;
@@ -22,29 +22,27 @@ const app = createReactAppExpress({
   clientBuildPath,
   universalRender: handleUniversalRender,
   onFinish(req, res, html) {
+    const state = store.getState();
     const { helmet } = helmetCtx;
     const helmetTitle = helmet.title.toString();
     const helmetMeta = helmet.meta.toString();
     const newHtml = html
-      .replace('{{HELMET_TITLE}}', helmetTitle)
-      .replace('{{HELMET_META}}', helmetMeta);
+      .replace(' <script class="helmet-title"></script>', helmetTitle)
+      .replace(' <script class="helmet-meta"></script>', helmetMeta)
+      .replace(
+        '<script class="initial-data"></script>',
+        `<script>
+          window.__PRELOADED_STATE__ = ${JSON.stringify(state).replace(
+            /</g,
+            '\\u003c'
+          )};
+          window.__INITIAL_DATA__ = ${JSON.stringify(serverData).replace(
+            /</g,
+            '\\u003c'
+          )};
+        </script>`);
+
     res.send(newHtml);
-  },
-  onEndReplace(html) {
-    const state = store.getState();
-    return html.replace(
-      '{{SCRIPT}}',
-      `${tag}<script>
-      window.__PRELOADED_STATE__ = ${JSON.stringify(state).replace(
-        /</g,
-        '\\u003c'
-      )};
-      window.__INITIAL_DATA__ = ${JSON.stringify(serverData).replace(
-        /</g,
-        '\\u003c'
-      )};
-    </script>`
-    );
   }
 });
 


### PR DESCRIPTION
- Cleaned up the `index.html`: to allow the up still to be executable without ssr, it's better to keep `index.html` as a valid html, so instead of `{{templates}}`, used empty script tags.
- Moved all the template replacements from `onEndReplace` to `onFinish`